### PR TITLE
Prevent integer out-of-range for "mode"

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ exports.ext = {
  */
 
 function Library (name, mode) {
-  if (!(this instanceof Library)) return new Library(name);
+  if (!(this instanceof Library)) return new Library(name, mode);
 
   if (name) {
     // append the `ext` if necessary

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -4,6 +4,8 @@
 
 #include <dlfcn.h>
 
+#include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -41,7 +43,10 @@ NAN_METHOD(Dlopen) {
   /* figure out which RTLD "mode" to use */
   int mode;
   if (args[2]->IsNumber()) {
-    mode = args[2]->IntegerValue();
+    int64_t orig = args[2]->IntegerValue();
+    if (orig > INT_MAX || orig < INT_MIN)
+      return NanThrowRangeError("Mode exceeds the range of C int");
+    mode = orig;
   } else {
     mode = RTLD_LAZY;
   }


### PR DESCRIPTION
`mode` is accessed using `V8::Value::IntegerValue()`, which returns `int64_t` rather than `int`. I'm not terribly good with C(++) spec, but in the worst case I think the behavior might be undefined.

This PR fixes that, and another minor bug in which you can't use `dl('lib', 1)` without `new`.

V8 does have a `V8::Value::Int32Value()`, but the size of `int` and `int32_t` might technically be different (it must be as large as `int16_t`:

> Their implementation-defined values shall be equal or greater in magnitude (absolute value) to those shown, with the same sign.  
> [...]
> - minimum value for an object of type `int`  
>   `INT_MIN -32767 // −(2^15 − 1)`
> - maximum value for an object of type `int`  
>   `INT_MAX +32767 // 2^15 − 1`
